### PR TITLE
Fixes recall wrench

### DIFF
--- a/SummerUpdate.ahk
+++ b/SummerUpdate.ahk
@@ -570,7 +570,7 @@ searchItem(search := "nil") {
         Sleep, 50
 
         if (search = "recall") {
-            uiUniversal("2211550554155055", 1, 1)
+            uiUniversal("22211550554155055", 1, 1)
         }
 
         uiUniversal(10)


### PR DESCRIPTION
Now only start macro if recall wrench is in inventory. Otherwise your inventory gets sorted by favs and wont craft.